### PR TITLE
Fix infinite loops with malformed PE headers

### DIFF
--- a/signify/signed_pe.py
+++ b/signify/signed_pe.py
@@ -179,7 +179,7 @@ class SignedPEFile(object):
         while position < sum(locations['certtable']):
             # check if this position is viable, we need at least 8 bytes for our header
             if position + 8 > self._filelength:
-                continue
+                raise SignedPEParseError("Position of certificate table is beyond length of file")
             self.file.seek(position, os.SEEK_SET)
             length = struct.unpack('<I', self.file.read(4))[0]
             revision = struct.unpack('<H', self.file.read(2))[0]
@@ -187,7 +187,7 @@ class SignedPEFile(object):
 
             # check if we are not going to perform a negative read (and 0 bytes is weird as well)
             if length <= 8:
-                continue
+                raise SignedPEParseError("Invalid length in certificate table header")
             certificate = self.file.read(length - 8)
 
             yield {'revision': revision, 'type': certificate_type, 'certificate': certificate}


### PR DESCRIPTION
There are two continue statements in `_parse_cert_table()` that will cause the function to loop indefinitely with malformed offsets.

This replaces the continues with exceptions.