### PR TITLE
Fix issues with certvalidator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+git+https://github.com/wbond/certvalidator@74ae7a8#egg=certvalidator==0.12.0.dev1
 pyasn1
-certvalidator
 asn1crypto
 oscrypto
 pyasn1-modules

--- a/signify/context.py
+++ b/signify/context.py
@@ -243,7 +243,7 @@ class VerificationContext(object):
         timestamp = self.timestamp
         context = ValidationContext(
             trust_roots=list(trust_roots),
-            moment=timestamp,
+            moment=timestamp if not self.allow_fetching else None,
             weak_hash_algos=set() if self.allow_legacy else None,
             revocation_mode=self.revocation_mode,
             allow_fetching=self.allow_fetching,

--- a/tests/test_authenticode.py
+++ b/tests/test_authenticode.py
@@ -137,6 +137,14 @@ class AuthenticodeParserTestCase(unittest.TestCase):
             pefile = SignedPEFile(f)
             pefile.verify()
 
+    def test_3a7de393a36ca8911cd0842a9a25b058_valid_with_crl_fetching(self):
+        """works when timestamp is defined and CRL fetching enabled"""
+        with open(str(root_dir / "test_data" / "3a7de393a36ca8911cd0842a9a25b058"), "rb") as f:
+            pefile = SignedPEFile(f)
+            pefile.verify(verification_context_kwargs=
+                          {'timestamp': datetime.datetime(2019, 1, 1, tzinfo=datetime.timezone.utc),
+                           'allow_fetching': True, 'revocation_mode': 'hard-fail'})
+
     def test_solwarwinds_valid_countersignature_rfc3161(self):
         """Solarwinds includes a 1.3.6.1.4.1.311.3.3.1 type countersignature"""
         with open(str(root_dir / "test_data" / "SolarWinds.exe"), "rb") as f:


### PR DESCRIPTION
There are some minor issues with certvalidator that need to be addressed:
1. ```ValueError: allow_fetching must be False when moment is specified```

It does not allow to specify moment when allow_fetching is enabled (https://github.com/wbond/certvalidator/issues/27).
I added a test to reproduce this. Fix is really simple, do not pass timestamp to ValidationContext if allow_fetching is set to True.

2. ```AttributeError: 'Void' object has no attribute 'human_friendly'```

The verification in _test_jameslth_revoked_ raises an exception, but it's not the one that it should be (https://github.com/wbond/certvalidator/issues/26).
By default certvalidator@0.11.1 is being installed - released 29 July 2016.
This error been fixed in https://github.com/wbond/certvalidator/commit/80119e8fa801327a34bdff4f73092f550919d169 - commit from 9 May 2017.
I changed requirements.txt to force installation directly from GitHub.
