### PR TITLE
Add pyinstaller hook

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ except Exception:
 setup(
     name='signify',
     version=about['__version__'],
-    packages=['signify', 'signify.asn1', 'signify.authenticode', 'signify.pkcs7', 'signify.x509'],
+    packages=['signify', 'signify.asn1', 'signify.authenticode', 'signify.pkcs7', 'signify.x509',
+              'signify.__pyinstaller'],
     package_data={'signify': ['*.pem']},
     include_package_data=True,
 
@@ -53,4 +54,9 @@ setup(
         'Topic :: System :: Software Distribution',
         'Topic :: Utilities',
     ],
+    entry_points={
+        'pyinstaller40': [
+            'hook-dirs = signify.__pyinstaller:get_hook_dirs'
+        ]
+    }
 )

--- a/signify/__pyinstaller/__init__.py
+++ b/signify/__pyinstaller/__init__.py
@@ -1,0 +1,5 @@
+import os
+
+
+def get_hook_dirs():
+    return [os.path.dirname(__file__)]

--- a/signify/__pyinstaller/hook-signify.py
+++ b/signify/__pyinstaller/hook-signify.py
@@ -1,0 +1,10 @@
+# This is a PyInstaller `hook
+# <https://pyinstaller.readthedocs.io/en/stable/hooks.html>`_.
+# See the `PyInstaller manual <https://pyinstaller.readthedocs.io/>`_
+# for more information.
+#
+import os
+from pathlib import Path
+
+datas = [(os.path.join(Path(__file__).parent, "..", "certs"), "signify/certs")]
+hiddenimports = ['encodings']


### PR DESCRIPTION
This PR adds a hook for PyInstaller that includes the `encodings` package and copies the `certs` directory into the frozen pyinstaller executable.

For more documentation on packaging pyinstaller hooks with the package itself, see https://pyinstaller.org/en/stable/hooks.html#providing-pyinstaller-hooks-with-your-package

Fixes #23