### PR TITLE
Add full import path to example script to allow running out of the box

### DIFF
--- a/examples/authenticode_info.py
+++ b/examples/authenticode_info.py
@@ -1,7 +1,7 @@
 import logging
 import sys
 
-from authenticode import SignedPEFile
+from signify.authenticode import SignedPEFile
 
 
 def main(*filenames):


### PR DESCRIPTION
Trivial change just to allow running of the example script in place once signify is installed.