### PR TITLE
Remove pyinstaller hook

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,5 @@ setup(
         'Topic :: Security :: Cryptography',
         'Topic :: System :: Software Distribution',
         'Topic :: Utilities',
-    ],
-    entry_points={
-        'pyinstaller40': [
-            'hook-dirs = signify.__pyinstaller:get_hook_dirs'
-        ]
-    }
+    ]
 )

--- a/signify/__init__.py
+++ b/signify/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 
 def _print_type(t):


### PR DESCRIPTION
With version 0.5.0 the certificates moved to a different project and also the pyinstaller hook that includes the certificates is gone now.

However, the entrypoint hook for pyinstaller to find the hook is still there and leads to a warning when using this package in a pyinstaller build.